### PR TITLE
Fix build using CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
 			SRCS "desfireaes.c"
 			INCLUDE_DIRS "include"
+			REQUIRES mbedtls
 )


### PR DESCRIPTION
Part of a collection of updates to allow the ESP32 code to build via CMake. [1/3]